### PR TITLE
making sure is passing a string to the codeMirror 

### DIFF
--- a/ui-codemirror.js
+++ b/ui-codemirror.js
@@ -91,7 +91,10 @@ angular.module('ui.codemirror', [])
             // Override the ngModelController $render method, which is what gets called when the model is updated.
             // This takes care of the synchronizing the codeMirror element with the underlying model, in the case that it is changed by something else.
             ngModel.$render = function () {
-              codeMirror.setValue(ngModel.$viewValue || '');		//Code mirror expectes a string so make sure it gets one
+			  //Code mirror expects a string so make sure it gets one
+			  //Although the formatter have already done this, it can be possible that another formatter returns undefined (for example the required directive)
+			  var safeViewValue = ngModel.$viewValue || '';
+              codeMirror.setValue(safeViewValue);		
             };
   
             if (!ngModel.$viewValue){


### PR DESCRIPTION
codeMirror expectes a string.

Adding a formatter is not enough to make sure that the editor receives a
sting, since the ngModel can have multiple formatters registered.

For example, if we have a ui-codemirror textarea combined with required

``` HTML
<textarea name="myfield" ui-codemirror required
ng-model="vm.myfield"></textarea>
```

the ngModel will have two formatters: the ui-codemirror and the
required.

When $scope.vm.myfield is undefined, the required formatter  returns
undefined, and this will be the last formatter to run

Here is the exception we will get from codemirror

TypeError: Cannot call method 'split' of undefined
at window.CodeMirror.splitLines
(http://localhost:1995/Scripts/codemirror/codemirror.js:5570:38)
at window.CodeMirror.createObj.setValue
(http://localhost:1995/Scripts/codemirror/codemirror.js:4773:31)
at null.setValue
(http://localhost:1995/Scripts/codemirror/codemirror.js:4972:40)
at link.ngModel.$render
(http://localhost:1995/Scripts/ui-codemirror.js:81:26)
at Object.ngModelWatch
(http://localhost:1995/Scripts/angular.js:14504:14)
at Object.watchExpression (<anonymous>:754:29)
at Scope.$digest (http://localhost:1995/Scripts/angular.js:9897:47)
at Scope.$delegate.**proto**.$digest (<anonymous>:844:31)
at Scope.$apply (http://localhost:1995/Scripts/angular.js:10137:24)
at Scope.$delegate.**proto**.$apply (<anonymous>:855:30)

Here is the formatter of required directive (from angular sources)

``` javascript
var validator = function(value) {
        if (attr.required &&
(isEmpty(value) || value === false)) {

ctrl.$setValidity('required', false);
          return;
        } else
{
          ctrl.$setValidity('required', true);
          return
value;
        }
      };

      ctrl.$formatters.push(validator);
```

As we can se the formatter returns undefined if the value isEmpty
