### PR TITLE
bug fix: cannot watch a dotted property

### DIFF
--- a/ui-codemirror.js
+++ b/ui-codemirror.js
@@ -56,7 +56,7 @@ angular.module('ui.codemirror', [])
 
           updateOptions(opts);
 
-          if (angular.isDefined(scope[iAttrs.uiCodemirror])) {
+          if (angular.isDefined(scope.$eval(iAttrs.uiCodemirror))) {
             scope.$watch(iAttrs.uiCodemirror, updateOptions, true);
           }
           // Specialize change event


### PR DESCRIPTION
use scope.$eval instead of scope[] in case `iAttrs.uiCodemirror` contains a dot.
