### PR TITLE
Angular 1.2.x model binding support

### DIFF
--- a/ui-codemirror.js
+++ b/ui-codemirror.js
@@ -9,6 +9,7 @@ angular.module('ui.codemirror', [])
     return {
       restrict: 'EA',
       require: '?ngModel',
+      priority: 1,
       compile: function compile(tElement, tAttrs, transclude) {
 
         // Require CodeMirror


### PR DESCRIPTION
Fixes an issue with model.$render appeared with angular 1.2.0-rc3 where the editor isn't updated when the model changes : https://github.com/angular/angular.js/issues/4560. This applies to ui-tinymce too.
Thanks to @iwang for the fix :
http://iwang.github.io/html/angular/angularjs/2013/11/04/ngmodel-render-cannot-be-overriden-in-angular-rc3.html
