### PR TITLE
Fix strict mode

### DIFF
--- a/src/ui-codemirror.js
+++ b/src/ui-codemirror.js
@@ -1,11 +1,10 @@
-'use strict';
-
 /**
  * Binds a CodeMirror widget to a <textarea> element.
  */
 angular.module('ui.codemirror', [])
   .constant('uiCodemirrorConfig', {})
   .directive('uiCodemirror', ['uiCodemirrorConfig', function (uiCodemirrorConfig) {
+    'use strict';
 
     return {
       restrict: 'EA',


### PR DESCRIPTION
Hi!

Because `"user strict";` is outside of the closure, it seems to apply to everything.
I have other dependencies in my project that breaks when minified together with ui-codemirror because of that.

I hope you will merge it and bump a new version soon.
Have a nice day!
