### PR TITLE
new feature: allow access to the CM instance through a $broadcast event

### DIFF
--- a/src/ui-codemirror.js
+++ b/src/ui-codemirror.js
@@ -108,6 +108,18 @@ angular.module('ui.codemirror', [])
             });
           }
 
+
+          // Allow access to the CodeMirror instance through a broadcasted event
+          // eg: $broadcast('CodeMirror', function(cm){...});
+          scope.$on('CodeMirror', function(event, callback){
+            if (angular.isFunction(callback)) {
+              callback(codeMirror);
+            } else {
+              throw new Error('the CodeMirror event requires a callback function');
+            }
+          });
+
+
           // onLoad callback
           if (angular.isFunction(opts.onLoad)) {
             opts.onLoad(codeMirror);

--- a/test/codemirror.spec.js
+++ b/test/codemirror.spec.js
@@ -247,6 +247,17 @@ describe('uiCodemirror', function () {
       expect(scope.codemirrorLoaded).toHaveBeenCalledWith(codemirror);
     });
 
+    it('responds to the $broadcast event "CodeMirror"', function () {
+      var broadcast = { callback: angular.noop };
+      spyOn(broadcast, 'callback');
+
+      $compile('<div ui-codemirror></div>')(scope);
+      scope.$broadcast('CodeMirror', broadcast.callback);
+
+      expect(broadcast.callback).toHaveBeenCalled();
+      expect(broadcast.callback).toHaveBeenCalledWith(codemirror);
+    });
+
 
     it('should watch the options', function () {
       spyOn(scope, '$watch').andCallThrough();


### PR DESCRIPTION
Currently the only way to interact with the CM instance is to get it through the onLoad callback (often storing it for later use).

I've added an event callback that allows direct and spontaneous access to the CM instance.

CoffeeScript example:

``` coffee
# in the controller that owns the <div ui-codemirror></div>
$scope.$broadcast 'CodeMirror', (cm) ->
  cm.scrollIntoView 1, 0
```

This allowed for much cleaner code in my controllers and link functions.
