### PR TITLE
Fix: set codeMirror instance into refresh fn

### DIFF
--- a/src/ui-codemirror.js
+++ b/src/ui-codemirror.js
@@ -140,7 +140,7 @@ function uiCodemirrorDirective($timeout, uiCodemirrorConfig) {
     scope.$watch(uiRefreshAttr, function(newVal, oldVal) {
       // Skip the initial watch firing
       if (newVal !== oldVal) {
-        $timeout(codeMirror.refresh);
+        $timeout(codeMirror.refresh.bind(codeMirror));
       }
     });
   }


### PR DESCRIPTION
There was the mistake on my pull request https://github.com/angular-ui/ui-codemirror/commit/1c03cacdd30d5b70cb0e8c15b6383fbfddeff6d2
Sorry for that
