### PR TITLE
fix:use of undefined this/scope

### DIFF
--- a/src/ui-codemirror.js
+++ b/src/ui-codemirror.js
@@ -140,7 +140,9 @@ function uiCodemirrorDirective($timeout, uiCodemirrorConfig) {
     scope.$watch(uiRefreshAttr, function(newVal, oldVal) {
       // Skip the initial watch firing
       if (newVal !== oldVal) {
-        $timeout(codeMirror.refresh);
+        $timeout(function() {
+          codeMirror.refresh();
+        });
       }
     });
   }


### PR DESCRIPTION
Fixes #83 by wrapping the `codeMirror.refresh` call in a function.
