### PR TITLE
Made ui-codemirror work with updateOn: 'blur'

### DIFF
--- a/src/ui-codemirror.js
+++ b/src/ui-codemirror.js
@@ -10,7 +10,7 @@ angular.module('ui.codemirror', [])
 /**
  * @ngInject
  */
-function uiCodemirrorDirective($timeout, uiCodemirrorConfig) {
+function uiCodemirrorDirective($timeout, $rootScope, uiCodemirrorConfig) {
 
   return {
     restrict: 'EA',
@@ -132,6 +132,28 @@ function uiCodemirrorDirective($timeout, uiCodemirrorConfig) {
         });
       }
     });
+
+    // Commit as with NgModelController
+    codemirror.on('blur', function() {
+      if (ngModel.$touched) {
+        return;
+      }
+
+      if ($rootScope.$$phase) {
+    	  scope.$evalAsync(ngModel.$setTouched);
+      } else {
+    	  scope.$apply(ngModel.$setTouched);
+      }
+    });
+
+    // Debounce as with NgModelController
+    if (ngModel.$options && ngModel.$options.updateOn) {
+      ngModel.$options.updateOn.split(/\s+/).forEach(function(trigger) {
+        codemirror.on(trigger, function() {
+      	  ngModel.$$debounceViewValueCommit(trigger);
+        });
+      });
+    }
   }
 
   function configUiRefreshAttribute(codeMirror, uiRefreshAttr, scope) {

--- a/test/codemirror.spec.js
+++ b/test/codemirror.spec.js
@@ -111,6 +111,7 @@ describe('uiCodemirror', function() {
           return codemirror;
         });
 
+      window.CodeMirror.signal   = _constructor.signal;
       window.CodeMirror.defaults = codemirrorDefaults;
     });
 
@@ -272,6 +273,34 @@ describe('uiCodemirror', function() {
       expect(ctrl.$valid).toBe(true);
       expect(ctrl.$dirty).toBe(true);
 
+    });
+
+    it('when the IDE changes should update the model on blur', function() {
+      // Define values
+      var oldValue = 'bar';
+      var newValue = 'baz';
+
+      // Create codemirror editor and bind with updateOn blur
+      var element = $compile('<div ui-codemirror ng-model="foo" ng-model-options="{updateOn: \'blur\'}"></div>')(scope);
+      var ctrl = element.controller('ngModel');
+
+      // Check initial states
+      expect(ctrl.$pristine).toBe(true);
+      expect(ctrl.$valid).toBe(true);
+      scope.$apply('foo = "' + oldValue + '"');
+      expect(scope.foo).toBe(oldValue);
+      expect(codemirror.getValue()).toBe(oldValue);
+
+      // Change text but DO NOT blur
+      codemirror.setValue(newValue);
+      expect(scope.foo).toBe(oldValue);
+      expect(codemirror.getValue()).toBe(newValue);
+
+      // Blur and observe change to model
+      window.CodeMirror.signal(codemirror, 'blur', codemirror);
+      expect(scope.foo).toBe(newValue);
+      expect(ctrl.$valid).toBe(true);
+      expect(ctrl.$dirty).toBe(true);
     });
 
     it('when the model changes should update the IDE', function() {


### PR DESCRIPTION
Adjusted slightly to respect "updateOn" ngModelOption attributes. Previously, if one specified `{updateOn: 'blur'}`, the model would never update.

The specific changes are;
1. A modification of `src/ui-codemirror.js' to add the necessary debounce and commit code (follows that in angular's ngmodel directive).
2. An additional unit test for the `{updateOn: 'blur'}` case.
