### PR TITLE
Add ability to create codemirror with merge plugin, fixes #91

### DIFF
--- a/src/ui-codemirror.js
+++ b/src/ui-codemirror.js
@@ -40,7 +40,7 @@ function uiCodemirrorDirective($timeout, uiCodemirrorConfig) {
     var showMergeView = angular.isDefined(iAttrs.mergeView);
 
     if(showMergeView) {
-      if(angular.isUndefined(CodeMirror.MergeView)) {
+      if(angular.isUndefined(window.CodeMirror.MergeView)) {
         throw new Error('merge-view needs the merge plugin and diff_match_patch to be loaded!');
       }
       codemirror = newCodemirrorMergeEditor(iElement, codemirrorOptions);


### PR DESCRIPTION
This let's you use the merge plugin by adding `merge-view` to the directive.

Example:

```
<ui-codemirror
    merge-view
    ui-codemirror-opts="options"
    ng-model="editCopy">
</ui-codemirror>
```
- 

```
$scope.options = {
        orig: 'StringToCompareWith',
        lineNumbers: true,
        highlightDifferences: true,
        connect: true,
        collapseIdentical: false
}
```
