### PR TITLE
Scope scrict mode to IIFE

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,6 +18,7 @@
     "grunt-conventional-changelog": "~1.1.0",
     "grunt-karma": "~0.9.0",
     "grunt-ng-annotate": "0.8.0",
+    "jasmine-core": "^2.4.1",
     "karma": "~0.12.0",
     "karma-chrome-launcher": "~0.1.1",
     "karma-coffee-preprocessor": "~0.2.1",

--- a/src/ui-codemirror.js
+++ b/src/ui-codemirror.js
@@ -1,150 +1,153 @@
-'use strict';
+(function () {
+  'use strict';
 
-/**
- * Binds a CodeMirror widget to a <textarea> element.
- */
-angular.module('ui.codemirror', [])
-  .constant('uiCodemirrorConfig', {})
-  .directive('uiCodemirror', uiCodemirrorDirective);
+  /**
+   * Binds a CodeMirror widget to a <textarea> element.
+   */
+  angular.module('ui.codemirror', [])
+    .constant('uiCodemirrorConfig', {})
+    .directive('uiCodemirror', uiCodemirrorDirective);
 
-/**
- * @ngInject
- */
-function uiCodemirrorDirective($timeout, uiCodemirrorConfig) {
+  /**
+   * @ngInject
+   */
+  function uiCodemirrorDirective($timeout, uiCodemirrorConfig) {
 
-  return {
-    restrict: 'EA',
-    require: '?ngModel',
-    compile: function compile() {
+    return {
+      restrict: 'EA',
+      require: '?ngModel',
+      compile: function compile() {
 
-      // Require CodeMirror
-      if (angular.isUndefined(window.CodeMirror)) {
-        throw new Error('ui-codemirror needs CodeMirror to work... (o rly?)');
+        // Require CodeMirror
+        if (angular.isUndefined(window.CodeMirror)) {
+          throw new Error('ui-codemirror needs CodeMirror to work... (o rly?)');
+        }
+
+        return postLink;
       }
+    };
 
-      return postLink;
+    function postLink(scope, iElement, iAttrs, ngModel) {
+
+      var codemirrorOptions = angular.extend(
+        { value: iElement.text() },
+        uiCodemirrorConfig.codemirror || {},
+        scope.$eval(iAttrs.uiCodemirror),
+        scope.$eval(iAttrs.uiCodemirrorOpts)
+      );
+
+      var codemirror = newCodemirrorEditor(iElement, codemirrorOptions);
+
+      configOptionsWatcher(
+        codemirror,
+        iAttrs.uiCodemirror || iAttrs.uiCodemirrorOpts,
+        scope
+      );
+
+      configNgModelLink(codemirror, ngModel, scope);
+
+      configUiRefreshAttribute(codemirror, iAttrs.uiRefresh, scope);
+
+      // Allow access to the CodeMirror instance through a broadcasted event
+      // eg: $broadcast('CodeMirror', function(cm){...});
+      scope.$on('CodeMirror', function(event, callback) {
+        if (angular.isFunction(callback)) {
+          callback(codemirror);
+        } else {
+          throw new Error('the CodeMirror event requires a callback function');
+        }
+      });
+
+      // onLoad callback
+      if (angular.isFunction(codemirrorOptions.onLoad)) {
+        codemirrorOptions.onLoad(codemirror);
+      }
     }
-  };
 
-  function postLink(scope, iElement, iAttrs, ngModel) {
+    function newCodemirrorEditor(iElement, codemirrorOptions) {
+      var codemirrot;
 
-    var codemirrorOptions = angular.extend(
-      { value: iElement.text() },
-      uiCodemirrorConfig.codemirror || {},
-      scope.$eval(iAttrs.uiCodemirror),
-      scope.$eval(iAttrs.uiCodemirrorOpts)
-    );
-
-    var codemirror = newCodemirrorEditor(iElement, codemirrorOptions);
-
-    configOptionsWatcher(
-      codemirror,
-      iAttrs.uiCodemirror || iAttrs.uiCodemirrorOpts,
-      scope
-    );
-
-    configNgModelLink(codemirror, ngModel, scope);
-
-    configUiRefreshAttribute(codemirror, iAttrs.uiRefresh, scope);
-
-    // Allow access to the CodeMirror instance through a broadcasted event
-    // eg: $broadcast('CodeMirror', function(cm){...});
-    scope.$on('CodeMirror', function(event, callback) {
-      if (angular.isFunction(callback)) {
-        callback(codemirror);
+      if (iElement[0].tagName === 'TEXTAREA') {
+        // Might bug but still ...
+        codemirrot = window.CodeMirror.fromTextArea(iElement[0], codemirrorOptions);
       } else {
-        throw new Error('the CodeMirror event requires a callback function');
+        iElement.html('');
+        codemirrot = new window.CodeMirror(function(cm_el) {
+          iElement.append(cm_el);
+        }, codemirrorOptions);
       }
-    });
 
-    // onLoad callback
-    if (angular.isFunction(codemirrorOptions.onLoad)) {
-      codemirrorOptions.onLoad(codemirror);
-    }
-  }
-
-  function newCodemirrorEditor(iElement, codemirrorOptions) {
-    var codemirrot;
-
-    if (iElement[0].tagName === 'TEXTAREA') {
-      // Might bug but still ...
-      codemirrot = window.CodeMirror.fromTextArea(iElement[0], codemirrorOptions);
-    } else {
-      iElement.html('');
-      codemirrot = new window.CodeMirror(function(cm_el) {
-        iElement.append(cm_el);
-      }, codemirrorOptions);
+      return codemirrot;
     }
 
-    return codemirrot;
-  }
+    function configOptionsWatcher(codemirrot, uiCodemirrorAttr, scope) {
+      if (!uiCodemirrorAttr) { return; }
 
-  function configOptionsWatcher(codemirrot, uiCodemirrorAttr, scope) {
-    if (!uiCodemirrorAttr) { return; }
+      var codemirrorDefaultsKeys = Object.keys(window.CodeMirror.defaults);
+      scope.$watch(uiCodemirrorAttr, updateOptions, true);
+      function updateOptions(newValues, oldValue) {
+        if (!angular.isObject(newValues)) { return; }
+        codemirrorDefaultsKeys.forEach(function(key) {
+          if (newValues.hasOwnProperty(key)) {
 
-    var codemirrorDefaultsKeys = Object.keys(window.CodeMirror.defaults);
-    scope.$watch(uiCodemirrorAttr, updateOptions, true);
-    function updateOptions(newValues, oldValue) {
-      if (!angular.isObject(newValues)) { return; }
-      codemirrorDefaultsKeys.forEach(function(key) {
-        if (newValues.hasOwnProperty(key)) {
+            if (oldValue && newValues[key] === oldValue[key]) {
+              return;
+            }
 
-          if (oldValue && newValues[key] === oldValue[key]) {
-            return;
+            codemirrot.setOption(key, newValues[key]);
           }
+        });
+      }
+    }
 
-          codemirrot.setOption(key, newValues[key]);
+    function configNgModelLink(codemirror, ngModel, scope) {
+      if (!ngModel) { return; }
+      // CodeMirror expects a string, so make sure it gets one.
+      // This does not change the model.
+      ngModel.$formatters.push(function(value) {
+        if (angular.isUndefined(value) || value === null) {
+          return '';
+        } else if (angular.isObject(value) || angular.isArray(value)) {
+          throw new Error('ui-codemirror cannot use an object or an array as a model');
+        }
+        return value;
+      });
+
+
+      // Override the ngModelController $render method, which is what gets called when the model is updated.
+      // This takes care of the synchronizing the codeMirror element with the underlying model, in the case that it is changed by something else.
+      ngModel.$render = function() {
+        //Code mirror expects a string so make sure it gets one
+        //Although the formatter have already done this, it can be possible that another formatter returns undefined (for example the required directive)
+        var safeViewValue = ngModel.$viewValue || '';
+        codemirror.setValue(safeViewValue);
+      };
+
+
+      // Keep the ngModel in sync with changes from CodeMirror
+      codemirror.on('change', function(instance) {
+        var newValue = instance.getValue();
+        if (newValue !== ngModel.$viewValue) {
+          scope.$evalAsync(function() {
+            ngModel.$setViewValue(newValue);
+          });
         }
       });
     }
+
+    function configUiRefreshAttribute(codeMirror, uiRefreshAttr, scope) {
+      if (!uiRefreshAttr) { return; }
+
+      scope.$watch(uiRefreshAttr, function(newVal, oldVal) {
+        // Skip the initial watch firing
+        if (newVal !== oldVal) {
+          $timeout(function() {
+            codeMirror.refresh();
+          });
+        }
+      });
+    }
+
   }
 
-  function configNgModelLink(codemirror, ngModel, scope) {
-    if (!ngModel) { return; }
-    // CodeMirror expects a string, so make sure it gets one.
-    // This does not change the model.
-    ngModel.$formatters.push(function(value) {
-      if (angular.isUndefined(value) || value === null) {
-        return '';
-      } else if (angular.isObject(value) || angular.isArray(value)) {
-        throw new Error('ui-codemirror cannot use an object or an array as a model');
-      }
-      return value;
-    });
-
-
-    // Override the ngModelController $render method, which is what gets called when the model is updated.
-    // This takes care of the synchronizing the codeMirror element with the underlying model, in the case that it is changed by something else.
-    ngModel.$render = function() {
-      //Code mirror expects a string so make sure it gets one
-      //Although the formatter have already done this, it can be possible that another formatter returns undefined (for example the required directive)
-      var safeViewValue = ngModel.$viewValue || '';
-      codemirror.setValue(safeViewValue);
-    };
-
-
-    // Keep the ngModel in sync with changes from CodeMirror
-    codemirror.on('change', function(instance) {
-      var newValue = instance.getValue();
-      if (newValue !== ngModel.$viewValue) {
-        scope.$evalAsync(function() {
-          ngModel.$setViewValue(newValue);
-        });
-      }
-    });
-  }
-
-  function configUiRefreshAttribute(codeMirror, uiRefreshAttr, scope) {
-    if (!uiRefreshAttr) { return; }
-
-    scope.$watch(uiRefreshAttr, function(newVal, oldVal) {
-      // Skip the initial watch firing
-      if (newVal !== oldVal) {
-        $timeout(function() {
-          codeMirror.refresh();
-        });
-      }
-    });
-  }
-
-}
+})();


### PR DESCRIPTION
Using a file level 'use strict' has the potential to force other libraries into ES5 strict mode and cause issues when minified. 

The underlying CodeMirror library will break for example.  

`this` becomes `undefined` instead of the expected window object:
https://github.com/codemirror/CodeMirror/blob/4bdf6440429bc455f4ce39486d424fba0be7fa14/lib/codemirror.js#L16
