### PR TITLE
Explicit injection to solve error on minification or with angular strict-di

### DIFF
--- a/src/ui-codemirror.js
+++ b/src/ui-codemirror.js
@@ -149,4 +149,4 @@ function uiCodemirrorDirective($timeout, uiCodemirrorConfig) {
 
 }
 
-uiCodemirrorDirective.$inject = [ "$timeout", "uiCodemirrorConfig" ];
+uiCodemirrorDirective.$inject = [ '$timeout', 'uiCodemirrorConfig' ];

--- a/src/ui-codemirror.js
+++ b/src/ui-codemirror.js
@@ -148,3 +148,5 @@ function uiCodemirrorDirective($timeout, uiCodemirrorConfig) {
   }
 
 }
+
+uiCodemirrorDirective.$inject = [ "$timeout", "uiCodemirrorConfig" ];


### PR DESCRIPTION
Without explicit injection, minification leads to this error :
https://docs.angularjs.org/error/$injector/strictdi?p0=uiCodemirrorDirective
