### PR TITLE
[RFR] Fix Strict DI issues and remove ngAnnotate

### DIFF
--- a/gruntFile.js
+++ b/gruntFile.js
@@ -6,7 +6,7 @@ module.exports = function (grunt) {
   // Default task.
   grunt.registerTask('default', ['jshint', 'karma:unit']);
   grunt.registerTask('serve', ['connect:continuous', 'karma:continuous', 'watch']);
-  grunt.registerTask('dist', ['ngAnnotate', 'uglify']);
+  grunt.registerTask('dist', ['uglify']);
 
   // HACK TO ACCESS TO THE COMPONENT-PUBLISHER
   function fakeTargetTask(prefix){
@@ -113,18 +113,9 @@ module.exports = function (grunt) {
       options: {banner: '<%= meta.banner %>'},
       build: {
         expand: true,
-        cwd: 'dist',
-        src: ['*.js'],
-        ext: '.min.js',
-        dest: 'dist'
-      }
-    },
-
-    ngAnnotate: {
-      main: {
-        expand: true,
         cwd: 'src',
         src: ['*.js'],
+        ext: '.min.js',
         dest: 'dist'
       }
     },

--- a/package.json
+++ b/package.json
@@ -17,7 +17,6 @@
     "grunt-contrib-watch": "~0.6.0",
     "grunt-conventional-changelog": "~1.1.0",
     "grunt-karma": "~0.9.0",
-    "grunt-ng-annotate": "0.8.0",
     "karma": "~0.12.0",
     "karma-chrome-launcher": "~0.1.1",
     "karma-coffee-preprocessor": "~0.2.1",

--- a/src/ui-codemirror.js
+++ b/src/ui-codemirror.js
@@ -5,7 +5,7 @@
  */
 angular.module('ui.codemirror', [])
   .constant('uiCodemirrorConfig', {})
-  .directive('uiCodemirror', uiCodemirrorDirective);
+  .directive('uiCodemirror', ['$timeout', 'uiCodemirrorConfig', uiCodemirrorDirective]);
 
 /**
  * @ngInject


### PR DESCRIPTION
This PR aims to solve an issue when importing this module in a Strict Dependency Injection environment. Indeed, using current version, installed with `npm`, we get the following Angular error:

> Error: [$injector:strictdi] http://errors.angularjs.org/1.4.12/$injector/strictdi?p0=uiCodemirrorDirective

Bower version is not impacted as `ng-annotate` plugin seems to be used in this case.

As source file is already compatible with strict DI, I also removed the obsolete `ng-annotate` plugin.
