### PR TITLE
Adding dependency injection for webpack uglifyjs

### DIFF
--- a/src/ui-codemirror.js
+++ b/src/ui-codemirror.js
@@ -5,7 +5,7 @@
  */
 angular.module('ui.codemirror', [])
   .constant('uiCodemirrorConfig', {})
-  .directive('uiCodemirror', uiCodemirrorDirective);
+  .directive('uiCodemirror', ['$timeout', 'uiCodemirrorConfig', uiCodemirrorDirective]);
 
 /**
  * @ngInject


### PR DESCRIPTION
The lack of dependency injection was breaking `webpack.optimize.UglifyJsPlugin`.
