### PR TITLE
Codemirror last version 5.20, doesnt support bower

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -22,7 +22,7 @@
   },
   "dependencies": {
     "angular": "^1.3",
-    "codemirror": "^5.0"
+    "codemirror": "~5.19.0"
   },
   "devDependencies": {
     "angular-mocks": "^1.3"


### PR DESCRIPTION
Codemirror last version 5.20, doesnt support bower
