### PR TITLE
Drop support from bower

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -22,7 +22,6 @@
   },
   "dependencies": {
     "angular": "^1.3"
-    //"codemirror": "https://github.com/codemirror/CodeMirror.git#master"
   },
   "devDependencies": {
     "angular-mocks": "^1.3"

--- a/bower.json
+++ b/bower.json
@@ -22,7 +22,7 @@
   },
   "dependencies": {
     "angular": "^1.3",
-    "codemirror": "https://github.com/codemirror/CodeMirror.git"
+    "codemirror": "https://github.com/codemirror/CodeMirror.git#master"
   },
   "devDependencies": {
     "angular-mocks": "^1.3"

--- a/bower.json
+++ b/bower.json
@@ -21,8 +21,8 @@
     "url": "https://github.com/angular-ui/ui-codemirror.git"
   },
   "dependencies": {
-    "angular": "^1.3",
-    "codemirror": "https://github.com/codemirror/CodeMirror.git#master"
+    "angular": "^1.3"
+    //"codemirror": "https://github.com/codemirror/CodeMirror.git#master"
   },
   "devDependencies": {
     "angular-mocks": "^1.3"

--- a/bower.json
+++ b/bower.json
@@ -22,7 +22,7 @@
   },
   "dependencies": {
     "angular": "^1.3",
-    "codemirror": "^5.0"
+    "codemirror": "https://github.com/codemirror/CodeMirror.git"
   },
   "devDependencies": {
     "angular-mocks": "^1.3"

--- a/bower.json
+++ b/bower.json
@@ -6,9 +6,6 @@
   "license": "MIT",
   "homepage": "http://angular-ui.github.com",
   "main": "./src/ui-codemirror.js",
-  "scripts": {
-    "postinstall": "echo 'post install bower'"
-  },
   "ignore": [
     "**/.*",
     "node_modules",

--- a/bower.json
+++ b/bower.json
@@ -6,6 +6,9 @@
   "license": "MIT",
   "homepage": "http://angular-ui.github.com",
   "main": "./src/ui-codemirror.js",
+  "scripts": {
+    "postinstall": "echo 'post install bower'"
+  },
   "ignore": [
     "**/.*",
     "node_modules",


### PR DESCRIPTION
Look like CodeMirror bower support was dropped so this change points the dependency straight to the CodeMirror repo. 