### PR TITLE
Use inline array annotation for dependency injection

### DIFF
--- a/src/ui-codemirror.js
+++ b/src/ui-codemirror.js
@@ -5,7 +5,7 @@
  */
 angular.module('ui.codemirror', [])
   .constant('uiCodemirrorConfig', {})
-  .directive('uiCodemirror', uiCodemirrorDirective);
+  .directive('uiCodemirror', ['$timeout', 'uiCodemirrorConfig', uiCodemirrorDirective]);
 
 /**
  * @ngInject


### PR DESCRIPTION
This allows projects that use ui-codemirror to minify JS files and avoid errors such as: Unknown provider: aProvider <- a <- uiCodemirrorDirective.