### PR TITLE
Added dependency injection and blur event

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "angular-ui-codemirror",
-  "version": "0.3.0",
+  "version": "0.3.1",
   "description": "This directive allows you to add CodeMirror to your textarea elements.",
   "author": "https://github.com/angular-ui/ui-codemirror/contributors",
   "license": "MIT",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "angular-ui-codemirror",
-  "version": "0.3.1",
+  "version": "0.3.2",
   "description": "This directive allows you to add CodeMirror to your textarea elements.",
   "author": "https://github.com/angular-ui/ui-codemirror/contributors",
   "license": "MIT",

--- a/src/ui-codemirror.js
+++ b/src/ui-codemirror.js
@@ -64,22 +64,22 @@ function uiCodemirrorDirective($timeout, uiCodemirrorConfig) {
   }
 
   function newCodemirrorEditor(iElement, codemirrorOptions) {
-    var codemirrot;
+    var codemirror;
 
     if (iElement[0].tagName === 'TEXTAREA') {
       // Might bug but still ...
-      codemirrot = window.CodeMirror.fromTextArea(iElement[0], codemirrorOptions);
+      codemirror = window.CodeMirror.fromTextArea(iElement[0], codemirrorOptions);
     } else {
       iElement.html('');
-      codemirrot = new window.CodeMirror(function(cm_el) {
+      codemirror = new window.CodeMirror(function(cm_el) {
         iElement.append(cm_el);
       }, codemirrorOptions);
     }
 
-    return codemirrot;
+    return codemirror;
   }
 
-  function configOptionsWatcher(codemirrot, uiCodemirrorAttr, scope) {
+  function configOptionsWatcher(codemirror, uiCodemirrorAttr, scope) {
     if (!uiCodemirrorAttr) { return; }
 
     var codemirrorDefaultsKeys = Object.keys(window.CodeMirror.defaults);
@@ -93,7 +93,7 @@ function uiCodemirrorDirective($timeout, uiCodemirrorConfig) {
             return;
           }
 
-          codemirrot.setOption(key, newValues[key]);
+          codemirror.setOption(key, newValues[key]);
         }
       });
     }
@@ -131,6 +131,14 @@ function uiCodemirrorDirective($timeout, uiCodemirrorConfig) {
           ngModel.$setViewValue(newValue);
         });
       }
+    });
+
+    // Emit HTML 'blur' event when editor loses focus
+    codemirror.on('blur', function(instance) {
+      angular
+        .element(instance.getWrapperElement())
+        .parent()
+        .trigger('blur');
     });
   }
 

--- a/src/ui-codemirror.js
+++ b/src/ui-codemirror.js
@@ -148,3 +148,5 @@ function uiCodemirrorDirective($timeout, uiCodemirrorConfig) {
   }
 
 }
+
+uiCodemirrorDirective.$inject = ['$timeout', 'uiCodemirrorConfig'];


### PR DESCRIPTION
Hi, this pull request contains the following changes:

- added dependency injection for "$timeout" and "uiCodemirrorConfig" to uiCodemirrorDirective
- fixed a typo ("codemirrot" -> "codemirror")
- emit HTML "blur" event when codemirror instance loses focus (this is required, for example, to update ngModel on blur through ngModelOptions)


Thanks!